### PR TITLE
Updated code to allow usage of SPI1/2 on RPi A+/B+/2/3 for python3

### DIFF
--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -55,10 +55,10 @@ class RFID:
         self.set_antenna(True)
 
     def spi_transfer(self, data):
-        if pin_ce != 0:
+        if self.pin_ce != 0:
 	        GPIO.output(pin_ce, 0)
         SPI.transfer(data)
-        if pin_ce != 0:
+        if self.pin_ce != 0:
 	        GPIO.output(pin_ce, 1)
 
     def dev_write(self, address, value):

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -58,10 +58,10 @@ class RFID:
 
     def spi_transfer(self, data):
         if self.pin_ce != 0:
-	        GPIO.output(pin_ce, 0)
+	        GPIO.output(self.pin_ce, 0)
         SPI.transfer(data)
         if self.pin_ce != 0:
-	        GPIO.output(pin_ce, 1)
+	        GPIO.output(self.pin_ce, 1)
 
     def dev_write(self, address, value):
         self.spi_transfer(((address << 1) & 0x7E, value))

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -59,9 +59,10 @@ class RFID:
     def spi_transfer(self, data):
         if self.pin_ce != 0:
 	        GPIO.output(self.pin_ce, 0)
-        SPI.transfer(data)
+        r = SPI.transfer(data)
         if self.pin_ce != 0:
 	        GPIO.output(self.pin_ce, 1)
+	    return r
 
     def dev_write(self, address, value):
         self.spi_transfer(((address << 1) & 0x7E, value))

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -62,10 +62,10 @@ class RFID:
 	        GPIO.output(pin_ce, 1)
 
     def dev_write(self, address, value):
-        spi_transfer(((address << 1) & 0x7E, value))
+        self.spi_transfer(((address << 1) & 0x7E, value))
 
     def dev_read(self, address):
-        return spi_transfer((((address << 1) & 0x7E) | 0x80, 0))[1]
+        return self.spi_transfer((((address << 1) & 0x7E) | 0x80, 0))[1]
 
     def set_bitmask(self, address, mask):
         current = self.dev_read(address)

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -126,7 +126,7 @@ class RFID:
                 error = False
 
                 if n & irq & 0x01:
-                    print "E1"
+                    print("E1")
                     error = True
 
                 if command == self.mode_transrec:
@@ -146,7 +146,7 @@ class RFID:
                     for i in range(n):
                         back_data.append(self.dev_read(0x09))
             else:
-                print "E2"
+                print("E2")
                 error = True
 
         return (error, back_data, back_length)

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -5,6 +5,7 @@ import time
 
 class RFID:
     pin_rst = 22
+    pin_ce = 0
 
     mode_idle = 0x00
     mode_auth = 0x0E
@@ -37,6 +38,7 @@ class RFID:
 
     def __init__(self, dev='/dev/spidev0.0', speed=1000000, pin_rst=22, pin_ce=0):
         self.pin_rst = pin_rst
+        self.pin_ce = pin_ce
 
         SPI.openSPI(device=dev, speed=speed)
         GPIO.setmode(GPIO.BOARD)

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -45,8 +45,8 @@ class RFID:
         GPIO.setup(pin_rst, GPIO.OUT)
         GPIO.output(pin_rst, 1)
         if pin_ce != 0:
-	        GPIO.setup(pin_ce, GPIO.OUT)
-	        GPIO.output(pin_ce, 1)
+            GPIO.setup(pin_ce, GPIO.OUT)
+            GPIO.output(pin_ce, 1)
         self.reset()
         self.dev_write(0x2A, 0x8D)
         self.dev_write(0x2B, 0x3E)
@@ -58,11 +58,11 @@ class RFID:
 
     def spi_transfer(self, data):
         if self.pin_ce != 0:
-	        GPIO.output(self.pin_ce, 0)
+            GPIO.output(self.pin_ce, 0)
         r = SPI.transfer(data)
         if self.pin_ce != 0:
-	        GPIO.output(self.pin_ce, 1)
-	    return r
+            GPIO.output(self.pin_ce, 1)
+        return r
 
     def dev_write(self, address, value):
         self.spi_transfer(((address << 1) & 0x7E, value))

--- a/ChipReader/RFID.py
+++ b/ChipReader/RFID.py
@@ -276,6 +276,19 @@ class RFID:
         self.clear_bitmask(0x08, 0x08)
         self.authed = False
 
+    def halt(self):
+        """Swich state to HALT"""
+
+        buf = []
+        buf.append(self.act_end)
+        buf.append(0)
+
+        crc = self.calculate_crc(buf)
+        self.clear_bitmask(0x08, 0x80)
+        self.card_write(self.mode_transrec, buf)
+        self.clear_bitmask(0x08, 0x08)
+        self.authed = False
+
     def read(self, block_address):
         """
         Reads data from block. You should be authenticated before calling read.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ while True:
       #Select Tag is required before Auth
       if not rdr.select_tag(uid):
         #Auth for block 10 (block 2 of sector 2) using default shipping key A
-        if rdr.card_auth(rdr.auth_a, 10, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], uid):
+        if not rdr.card_auth(rdr.auth_a, 10, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], uid):
           #This will print something like (False, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
           print "Reading block 10: " + str(rdr.read(10))
           #Always stop crypto1 when done working

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Connecting RC522 module to SPI is pretty easy. You can use [this neat website](h
 
 You can connect SDA pin also to CE1 (GPIO7, pin #26) and call the RFID constructor with *dev='/dev/spidev0.0'*
 and you can connect RST pin to any other free GPIO pin and call the constructor with *pin_rst=__BOARD numbering pin__*.
-__NOTE:__For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required.
+__NOTE:__For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.
 
 ## Usage
 The library is split to two classes - **RFID** and **RFIDUtil**. You can use only RFID, RFIDUtil just makes life a little bit better. 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Connecting RC522 module to SPI is pretty easy. You can use [this neat website](h
 
 You can connect SDA pin also to CE1 (GPIO7, pin #26) and call the RFID constructor with *dev='/dev/spidev0.0'*
 and you can connect RST pin to any other free GPIO pin and call the constructor with *pin_rst=__BOARD numbering pin__*.
+
 __NOTE:__For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Connecting RC522 module to SPI is pretty easy. You can use [this neat website](h
 
 You can connect SDA pin also to CE1 (GPIO7, pin #26) and call the RFID constructor with *dev='/dev/spidev0.0'*
 and you can connect RST pin to any other free GPIO pin and call the constructor with *pin_rst=__BOARD numbering pin__*.
+__NOTE:__For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required.
 
 ## Usage
 The library is split to two classes - **RFID** and **RFIDUtil**. You can use only RFID, RFIDUtil just makes life a little bit better. 
@@ -43,12 +44,14 @@ while True:
     (error, uid) = rdr.anticoll()
     if not error:
       print "UID: " + str(uid)
-      #Auth for block 10 (block 2 of sector 2) using default shipping key A
-      if rdr.card_auth(rdr.auth_a, 10, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], uid):
-        #This will print something like (False, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        print "Reading block 10: " + str(rdr.read(10))
-        #Always stop crypto1 when done working
-        rdr.stop_crypto()
+      #Select Tag is required before Auth
+      if not rdr.select_tag(uid):
+        #Auth for block 10 (block 2 of sector 2) using default shipping key A
+        if rdr.card_auth(rdr.auth_a, 10, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], uid):
+          #This will print something like (False, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+          print "Reading block 10: " + str(rdr.read(10))
+          #Always stop crypto1 when done working
+          rdr.stop_crypto()
       
       
 #Calls GPIO cleanup

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Connecting RC522 module to SPI is pretty easy. You can use [this neat website](h
 You can connect SDA pin also to CE1 (GPIO7, pin #26) and call the RFID constructor with *dev='/dev/spidev0.0'*
 and you can connect RST pin to any other free GPIO pin and call the constructor with *pin_rst=__BOARD numbering pin__*.
 
-__NOTE:__For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.
+__NOTE:__ For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.
 
 ## Usage
 The library is split to two classes - **RFID** and **RFIDUtil**. You can use only RFID, RFIDUtil just makes life a little bit better. 


### PR DESCRIPTION
Hi @ondryaso I've been using your code on my Raspberry Pi B and been working for a while. Recently I upgraded to Pi 2 and added touch screen. The cable length of the touch controller requires a much slower SPI speed to get it working properly, hence I switch the RFID module to using SPI1. But I ran into issue that SPI1/2 doesn't control CE pin [natively](https://www.kernel.org/doc/Documentation/devicetree/bindings/spi/brcm,bcm2835-aux-spi.txt).

Hence I made the changes to have `pin_ce` configuration and toggle from code. By default `pin_ce=0` so it will allow hardware SPI to have control though only works in SPI0.

Since I'm using python3, I've adopted the code for that as well, just minor changes on `print()`

Also, the usage example is missing `select_tag()` before calling `card_auth()`

Hope this is useful for you and anyone else in the future