### PR TITLE
switch to spidev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/ondryaso/pi-rc522.git
 cd pi-rc522
 python setup.py install
 ```
-You'll also need to install the [**SPI-Py**](https://github.com/lthiery/SPI-Py) and [**RPi.GPIO**](https://pypi.python.org/pypi/RPi.GPIO) libraries.
+You'll also need to install the [**spidev**](https://pypi.python.org/pypi/spidev) and [**RPi.GPIO**](https://pypi.python.org/pypi/RPi.GPIO) libraries.
 
 [MIFARE datasheet](http://www.nxp.com/documents/data_sheet/MF1S503x.pdf) can be useful.
 
@@ -34,7 +34,7 @@ Connecting RC522 module to SPI is pretty easy. You can use [this neat website](h
 | RST            | 7         | 22               | GPIO25       |
 | 3.3V           | 8         | 1                | 3V3          |
 
-You can also connect the SDA pin to CE1 (GPIO7, pin #26) and call the RFID constructor with *dev='/dev/spidev0.1'*
+You can also connect the SDA pin to CE1 (GPIO7, pin #26) and call the RFID constructor with *bus=0, device=1*
 and you can connect RST pin to any other free GPIO pin and call the constructor with *pin_rst=__BOARD numbering pin__*.
 
 __NOTE:__ For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.

--- a/pirc522/__init__.py
+++ b/pirc522/__init__.py
@@ -1,11 +1,11 @@
 import time
 import signal
 
-import spi as SPI
+import spidev
 import RPi.GPIO as GPIO
 
 
-__version__ = "1.1.0"
+__version__ = "2.0.0"
 
 
 class RFID(object):
@@ -41,11 +41,14 @@ class RFID(object):
 
     authed = False
 
-    def __init__(self, dev='/dev/spidev0.0', speed=1000000, pin_rst=22, pin_ce=0):
+    def __init__(self, bus=0, device=0, speed=1000000, pin_rst=22, pin_ce=0):
         self.pin_rst = pin_rst
         self.pin_ce = pin_ce
 
-        SPI.openSPI(device=dev, speed=speed)
+        self.spi = spidev.SpiDev()
+        self.spi.open(bus, device)
+        self.spi.max_speed_hz = speed
+
         GPIO.setmode(GPIO.BOARD)
         GPIO.setup(pin_rst, GPIO.OUT)
         GPIO.output(pin_rst, 1)
@@ -64,16 +67,16 @@ class RFID(object):
     def spi_transfer(self, data):
         if self.pin_ce != 0:
             GPIO.output(self.pin_ce, 0)
-        r = SPI.transfer(data)
+        r = self.spi.xfer2(data)
         if self.pin_ce != 0:
             GPIO.output(self.pin_ce, 1)
         return r
 
     def dev_write(self, address, value):
-        self.spi_transfer(((address << 1) & 0x7E, value))
+        self.spi_transfer([(address << 1) & 0x7E, value])
 
     def dev_read(self, address):
-        return self.spi_transfer((((address << 1) & 0x7E) | 0x80, 0))[1]
+        return self.spi_transfer([((address << 1) & 0x7E) | 0x80, 0])[1]
 
     def set_bitmask(self, address, mask):
         current = self.dev_read(address)


### PR DESCRIPTION
Use spidev library instead of py-spi.

Closes https://github.com/ondryaso/pi-rc522/issues/18.
Fixes an issue (tracked in the original project as https://github.com/mxgxw/MFRC522-python/issues/21) where the device stops reading tags after some time. (I only tested and therefore encountered this issue with my interrupt driven tag detection patch - I did not test if the same issue exists in master.)

I could not find information on the versioning schema - should I change the major version instead because it is an API change in the init function?
BTW: The [upcoming PR](https://github.com/LudwigKnuepfer/pi-rc522/tree/wip/irq) for https://github.com/ondryaso/pi-rc522/issues/9 requires an API change in the init function as well.