### PR TITLE
Variable Pinout definition (BCM/BOARD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Furthermore, the IRQ pin is configurable by passing *pin_irq=__BOARD numbering p
 
 __NOTE:__ For RPi A+/B+/2/3 with 40 pin connector, SPI1/2 is available on top of SPI0. Kernel 4.4.x or higher and *dtoverlay* configuration is required. For SPI1/2, *pin_ce=__BOARD numbering pin__* is required.
 
+You may change BOARD pinout to BCM py passing *pin_mode=RPi.GPIO.BCM*. Please note, that you then have to define all pins (irq+rst, ce if neccessary). Otherwise they would default to perhaps wrong pins (rst to pin 15/GPIO22, irq to pin 12/GPIO18).
+
 ## Usage
 The library is split to two classes - **RFID** and **RFIDUtil**. You can use only RFID, RFIDUtil just makes life a little bit better.
 You basically want to start with *while True* loop and "poll" the tag state. That's done using *request* method. Most of the methods

--- a/pirc522/__init__.py
+++ b/pirc522/__init__.py
@@ -43,7 +43,7 @@ class RFID(object):
     irq = threading.Event()
 
     def __init__(self, bus=0, device=0, speed=1000000, pin_rst=22,
-            pin_ce=0, pin_irq=18):
+            pin_ce=0, pin_irq=18, pin_mode=GPIO.BOARD):
         self.pin_rst = pin_rst
         self.pin_ce = pin_ce
         self.pin_irq = pin_irq
@@ -52,7 +52,7 @@ class RFID(object):
         self.spi.open(bus, device)
         self.spi.max_speed_hz = speed
 
-        GPIO.setmode(GPIO.BOARD)
+        GPIO.setmode(pin_mode)
         GPIO.setup(pin_rst, GPIO.OUT)
         GPIO.setup(pin_irq, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(pin_irq, GPIO.FALLING,

--- a/pirc522/__init__.py
+++ b/pirc522/__init__.py
@@ -4,7 +4,7 @@ import spidev
 import RPi.GPIO as GPIO
 
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 
 class RFID(object):


### PR DESCRIPTION
The hardcoded pin mode makes it sometimes hard to use it with other libraries. This could fix it.

Please note: pip install pi-rc522 does not work as mentioned (dependency on https://github.com/lthiery/SPI-Py which is != spidev).