### PR TITLE
Fix blocking when tag is on the reader for some time

### DIFF
--- a/pirc522/rfid.py
+++ b/pirc522/rfid.py
@@ -395,6 +395,11 @@ class RFID(object):
         # wait for it
         waiting = True
         while waiting:
+            self.init()
+            #self.irq.clear()
+            self.dev_write(0x04, 0x00)
+            self.dev_write(0x02, 0xA0)
+
             self.dev_write(0x09, 0x26)
             self.dev_write(0x01, 0x0C)
             self.dev_write(0x0D, 0x87)


### PR DESCRIPTION
* wait_for_tag() will hang after some time when a tag is permanently on the reader
* maybe this issue is related https://github.com/ondryaso/pi-rc522/issues/48
* fix was originally taken from calvinzirk/pi-rc522, he deserves all the credit
* see https://github.com/calvinzirk/pi-rc522/commit/dd30c448f2fa1b925145b45985c103b026511c33
* I'm testing the fix for some time now and can confirm that it works
