### PR TITLE
Add timeout to wait_for_tag method

### DIFF
--- a/pirc522/rfid.py
+++ b/pirc522/rfid.py
@@ -408,7 +408,7 @@ class RFID(object):
         self.dev_write(0x02, 0xA0)
         # wait for it
         waiting = True
-        while waiting and timeout > 0 and (time.time() - start_time) < timeout:
+        while waiting and (timeout == 0 or ((time.time() - start_time) < timeout)):
             self.init()
             #self.irq.clear()
             self.dev_write(0x04, 0x00)

--- a/pirc522/rfid.py
+++ b/pirc522/rfid.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 RASPBERRY = object()
 BEAGLEBONE = object()
@@ -398,15 +399,16 @@ class RFID(object):
     def irq_callback(self, pin):
         self.irq.set()
 
-    def wait_for_tag(self):
+    def wait_for_tag(self, timeout=0):
         # enable IRQ on detect
+        start_time = time.time()
         self.init()
         self.irq.clear()
         self.dev_write(0x04, 0x00)
         self.dev_write(0x02, 0xA0)
         # wait for it
         waiting = True
-        while waiting:
+        while waiting and timeout > 0 and (time.time() - start_time) < timeout:
             self.init()
             #self.irq.clear()
             self.dev_write(0x04, 0x00)


### PR DESCRIPTION
Based on @tlongeri 's suggestion in https://github.com/ondryaso/pi-rc522/issues/44
I addded the timeout functionality to the wait_for_tag method so that it will return after a given number of seconds. 
The timeout param is optional with default value of 0 (=no timeout) so that existing users of the library will not have any change in functionality unless they provide the new param.

This functionality is useful for detecting that the reader could not find a RFID tag, e.g. the card was removed.